### PR TITLE
Patch socket directly not just HTTP

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,8 @@
 # srv_hijacker
 
-A python module that patches [`urllib3`](https://urllib3.readthedocs.io/en/latest/)
-to query a certain DNS server for SRV records when creating connections.
+A python module that patches
+[`socket`](https://docs.python.org/3/library/socket.html) to query a certain DNS
+server for SRV records when creating connections.
 
 ### Installation
 
@@ -37,11 +38,10 @@ nameservers and ports configured.
 ### Compatibility
 
 Only confirmed to work with Python 3.7. Tests use `requests`, which uses
-`urllib3` internally.
+`socket` internally.
 
 ### Background
 
 The use case this was designed for is to transparently patch `requests` so that
 calls to endpoints like `your_service.service.consul` hit consul's DNS server
 and use the host + port given in the SRV query.
-

--- a/srv_hijacker/srv_hijacker.py
+++ b/srv_hijacker/srv_hijacker.py
@@ -1,11 +1,7 @@
-import os
 import re
 
-from socket import error as SocketError, timeout as SocketTimeout
-
-from urllib3.connection import HTTPConnection
-from urllib3.exceptions import NewConnectionError, ConnectTimeoutError
-from urllib3.util import connection
+import socket
+from socket import gaierror as SocketError
 
 from dns import resolver
 
@@ -19,7 +15,7 @@ def resolve_ip_for_target(rrsets, target):
         if rrset.name == target:
             return rrset.items[0].address
 
-    raise NewConnectionError("Couldn't find A record for target %s" % target)
+    raise SocketError("Couldn't find SRV record for target %s" % target)
 
 
 def resolve_srv_record(old_host, resolver):
@@ -35,28 +31,27 @@ def resolve_srv_record(old_host, resolver):
     return new_host, new_port
 
 
-original_new_conn = HTTPConnection._new_conn
+original_socket_getaddrinfo = socket.getaddrinfo
 
 
-def patched_new_conn(url_regex, srv_resolver):
+def patched_socket_getaddrinfo(host_regex, srv_resolver):
     """
-    Returns a function that does pretty much what
-    `urllib3.connection.HTTPConnection._new_conn` does.
+    Returns a function that behaves like `socket.getaddrinfo`.
 
-    url_regex:
+    host_regex:
 
-    The regex to match a host against. If this regex matches the host, we
-    hit the srv_resolver to fetch the new host + port
+    The regex to match a host against. If this regex matches the host
+    we hit srv_resolver to fetch the new host + port
     """
 
-    def patched_f(self):
-        if re.search(url_regex, self.host):
-            logger.debug("Host %s matched SRV regex, resolving", self.host)
-            self.host, self.port = resolve_srv_record(self.host, srv_resolver)
+    def patched_f(host, port, family=0, type=0, proto=0, flags=0):
+        if re.search(host_regex, host):
+            logger.debug("TCP host %s matched SRV regex, resolving", host)
+            host, port = resolve_srv_record(host, srv_resolver)
         else:
-            logger.debug("Host %s did not match SRV regex, ignoring", self.host)
+            logger.debug("TCP host %s did not match SRV regex, ignoring", host)
 
-        return original_new_conn(self)
+        return original_socket_getaddrinfo(host, port, family, type, proto, flags)
 
     return patched_f
 
@@ -79,4 +74,4 @@ def hijack(host_regex, srv_dns_host=None, srv_dns_port=None):
     if srv_dns_port:
         srv_resolver.port = int(srv_dns_port)
 
-    HTTPConnection._new_conn = patched_new_conn(host_regex, srv_resolver)
+    socket.getaddrinfo = patched_socket_getaddrinfo(host_regex, srv_resolver)

--- a/tests/test_srv_hijacker.py
+++ b/tests/test_srv_hijacker.py
@@ -1,6 +1,7 @@
-import srv_hijacker
-import requests
 import pytest
+import requests
+
+import srv_hijacker
 
 CONSUL_HOST = "127.0.0.1"
 CONSUL_DNS_PORT = "8600"
@@ -8,10 +9,23 @@ CONSUL_API_PORT = "8500"
 CONSUL_API_URL = f"{CONSUL_HOST}:{CONSUL_API_PORT}"
 
 
-def test_hijack(consul_test_service_url):
-    # Before 'hijack' is run, this request must fail
+def test_hijack(consul_http_service_url):
+    def test_http(url):
+        response = requests.get(url)
+        assert response.status_code == 200
+
+    def test_http_direct():
+        test_http("https://httpbin.org/get")
+
+    def test_http_hijacked():
+        test_http(consul_http_service_url)
+
+    # Before 'hijack' is run, direct requests must pass
+    test_http_direct()
+
+    # Before 'hijack' is run, hijacked requests must fail
     with pytest.raises(requests.exceptions.ConnectionError):
-        requests.get(consul_test_service_url)
+        test_http_hijacked()
 
     srv_hijacker.hijack(
         host_regex=r"service.consul$",
@@ -19,13 +33,9 @@ def test_hijack(consul_test_service_url):
         srv_dns_port=CONSUL_DNS_PORT,
     )
 
-    # Now that the monkey patching is done, this should succeed
-    response = requests.get(consul_test_service_url)
-    assert response.status_code == 200
-
-    # Making sure a normal requests passes even after the patch is done
-    response = requests.get("https://httpbin.org/get")
-    assert response.status_code == 200
+    # Now that the monkey patching is done, both should succeed
+    test_http_direct()
+    test_http_hijacked()
 
     # Patching again shouldn't cause issues
     srv_hijacker.hijack(
@@ -34,19 +44,17 @@ def test_hijack(consul_test_service_url):
         srv_dns_port=CONSUL_DNS_PORT,
     )
 
-    response = requests.get(consul_test_service_url)
-    assert response.status_code == 200
-    response = requests.get("https://httpbin.org/get")
-    assert response.status_code == 200
+    test_http_direct()
+    test_http_hijacked()
 
 
 @pytest.fixture
-def consul_test_service_url():
+def consul_http_service_url():
     # Let's register a service named 'test'  to point back to consul itself
-    register_service_on_consul("test", CONSUL_HOST, CONSUL_API_PORT)
+    register_service_on_consul("test-http", CONSUL_HOST, CONSUL_API_PORT)
 
     # We can now use a consul endpoint itself for testing.
-    return "http://test.service.consul/v1/agent/services"
+    return "http://test-http.service.consul/v1/agent/services"
 
 
 def register_service_on_consul(service_name, service_host, service_port):

--- a/tests/test_srv_hijacker.py
+++ b/tests/test_srv_hijacker.py
@@ -1,7 +1,6 @@
 import srv_hijacker
 import requests
 import pytest
-from uuid import uuid4
 
 CONSUL_HOST = "127.0.0.1"
 CONSUL_DNS_PORT = "8600"
@@ -15,7 +14,9 @@ def test_hijack(consul_test_service_url):
         requests.get(consul_test_service_url)
 
     srv_hijacker.hijack(
-        host_regex=r"service.consul$", srv_dns_host="127.0.0.1", srv_dns_port="8600"
+        host_regex=r"service.consul$",
+        srv_dns_host=CONSUL_HOST,
+        srv_dns_port=CONSUL_DNS_PORT,
     )
 
     # Now that the monkey patching is done, this should succeed
@@ -28,7 +29,9 @@ def test_hijack(consul_test_service_url):
 
     # Patching again shouldn't cause issues
     srv_hijacker.hijack(
-        host_regex=r"service.consul$", srv_dns_host="127.0.0.1", srv_dns_port="8600"
+        host_regex=r"service.consul$",
+        srv_dns_host=CONSUL_HOST,
+        srv_dns_port=CONSUL_DNS_PORT,
     )
 
     response = requests.get(consul_test_service_url)


### PR DESCRIPTION
https://github.com/rohitpaulk/srv_hijacker/pull/4, re-done to directly patch `socket` and not deal with the HTTP layer at all. 