### PR TITLE
Only consider A records when resolving IP

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 .PHONY: dig_consul test build upload bump_version commit_version_update bump_commit_upload
 
 dig_consul:
-	dig @127.0.0.1 -p 8600 test.service.consul SRV
+	dig @127.0.0.1 -p 8600 test-http.service.consul SRV
 
 run_consul:
 	consul agent -dev


### PR DESCRIPTION
If `CNAME` records were returned in the 'additional' section, we'd hit an error like this: 

```
AttributeError: 'CNAME' object has no attribute 'address'

File "srv_hijacker/srv_hijacker.py", line 50, in patched_f
    host, port = resolve_srv_record(host, srv_resolver)
  File "srv_hijacker/srv_hijacker.py", line 25, in resolve_srv_record
    new_host = resolve_ip_for_target(ans.response.additional, ans[0].target)
  File "srv_hijacker/srv_hijacker.py", line 16, in resolve_ip_for_target
    return rrset.items[0].address
```