### PR TITLE
Add ability to add a custom patch

### DIFF
--- a/srv_hijacker/__init__.py
+++ b/srv_hijacker/__init__.py
@@ -1,1 +1,1 @@
-from .srv_hijacker import hijack
+from .srv_hijacker import hijack, register, PatchError

--- a/srv_hijacker/srv_hijacker.py
+++ b/srv_hijacker/srv_hijacker.py
@@ -110,6 +110,15 @@ PATCHABLE_LIBS = {
 }
 
 
+def register(lib_name, patching_f):
+    global PATCHABLE_LIBS
+
+    if lib_name in PATCHABLE_LIBS:
+        logger.warn(f"Overridding existing patch for {lib_name}")
+
+    PATCHABLE_LIBS[lib_name] = patching_f
+
+
 def hijack(host_regex, srv_dns_host=None, srv_dns_port=None, libraries_to_patch=None):
     """
     Usage:

--- a/tests/test_srv_hijacker.py
+++ b/tests/test_srv_hijacker.py
@@ -57,3 +57,11 @@ class TestPatchSocketGetaddrinfo(StatefulTest):
 
         # We can now use a consul endpoint itself for testing.
         return "http://test-http.service.consul/v1/agent/services"
+
+
+def test_registering_a_new_patch_works():
+    with pytest.raises(srv_hijacker.PatchError):
+        srv_hijacker.hijack(host_regex=r"service.consul$", libraries_to_patch=["lol"])
+
+    srv_hijacker.register("lol", lambda x: x)
+    srv_hijacker.hijack("")


### PR DESCRIPTION
Now a client can add custom patches too.
Need to add for one lib, I thought this is a reasonable interface to provide. Else I'll have to patch the patcher, which is just too much patching won't you say.

Also: @rohitpaulk would you be willing to transfer ownership of this repo to @Shuttl-Tech :P 